### PR TITLE
Restart Workspace after tests if workspace went down

### DIFF
--- a/src/us/kbase/jgiintegration/test/JGIIntegrationTest.java
+++ b/src/us/kbase/jgiintegration/test/JGIIntegrationTest.java
@@ -32,6 +32,7 @@ import javax.mail.Store;
 import javax.mail.internet.MimeMultipart;
 
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -202,6 +203,29 @@ public class JGIIntegrationTest {
 		String wipePwd = System.getProperty("test.kbase.wipe_pwd");
 		if (!SKIP_WIPE) {
 			WIPE = wipeRemoteServer(new URL(WIPE_URL), wipeUser, wipePwd);
+		}
+	}
+
+	@AfterClass
+	public static void cleanUpClass() throws Exception {
+		// Check if the WS server is down after the tests; if so then we should restart
+		System.out.println("Checking Workspace server status...");
+		try {
+			WorkspaceClient wsCli = new WorkspaceClient(new URL("https://dev03.berkeley.kbase.us/services/ws"));
+			wsCli.setIsInsecureHttpConnectionAllowed(true);
+			wsCli.setAllSSLCertificatesTrusted(true);
+			wsCli.setConnectionReadTimeOut(5000);
+			System.out.println("Workspace is still running, version is: "+wsCli.ver());
+		} catch (Exception e) {
+			// we assume any exception means the server is down.
+			System.out.println("The Workspace service seems to be down - attempting a restart.");
+			Tuple2<Long, String> w = WIPE.restartWorkspace();
+			if (w.getE1() > 0 ) {
+				throw new WipeException(
+						"Restart of the test server failed. The wipe server said:\n" +
+								w.getE2());
+			}
+			System.out.println("Restart was successful. Server said:\n" + w.getE2());
 		}
 	}
 	


### PR DESCRIPTION
There is a test that stops the workspace service, attempts a push from JGI, makes sure that the push failed, and then restarts the workspace.  It that test fails somewhere after the workspace is stopped, then the workspace service remains down causing the next round of nightly tests to fail until the workspace is manually restarted.

This PR adds a simple check to see if the workspace is still running after all tests, and if it is down attempts to restart.

I don't have a good way of testing these changes without creating new test JGI account, gmail account, and rebooting the wipe service on dev03, so for now it's not tested.  However, it does compile, the wipe code is copied exactly from another test, and the code to test if the workspace is up/down was tested outside of this repo.

This isn't urgent to merge in right now, but will be useful so we should test it and get it in at some point.
